### PR TITLE
Upgrade plugin-scaffold, change minutes to seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
     "description": "Export PostHog events to Amazon Redshift on ingestion.",
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.3",
-        "@posthog/plugin-scaffold": "^0.7.1",
-        "pg": "^8.0.0",
-        "@types/pg": "^7.14.11"
-
+        "@posthog/plugin-scaffold": "^0.9.0",
+        "@types/pg": "^8.6.0",
+        "pg": "^8.0.0"
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -55,11 +55,11 @@
             "secret": true
         },
         {
-            "key": "uploadMinutes",
-            "name": "Upload at most every X minutes",
+            "key": "uploadSeconds",
+            "name": "Upload at least every X seconds",
             "type": "string",
-            "default": "1",
-            "hint": "If there are events to upload and this many minutes has passed since the last upload, send the events to Redshift. The value must be between 1 and 60 minutes.",
+            "default": "30",
+            "hint": "If there are events to upload and this many seconds has passed since the last upload, send the events to Redshift. The value must be between 1 and 600.",
             "required": true
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.3.tgz#d0772c6dd9ec9944ebee9dc475e1e781256b0b5f"
   integrity sha512-0HrE8AuPv3OLZA93RrJDbljn9u5D/wmiIkBCeckU3LL67LNozDIJgKsY4Td91zgc+b4Rlx/X0MJNp2l6BHbQqg==
 
-"@posthog/plugin-scaffold@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.7.1.tgz#801dce0d55e77851fc054bd8a6284de78b90f0a3"
-  integrity sha512-QkMkNpyGWLen6FCmPjpHmUsalHa8e5/6eenUS/vG4SKWMORod0VDVlDYnInUXzS+HYhIjKSlgprwAyCp+2KWfQ==
+"@posthog/plugin-scaffold@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.9.0.tgz#67f1eaeb526591ed6693dce2fd2eeb6a7ff69546"
+  integrity sha512-JvxTpIUsCzJcRqeEtQiAsigXyzG5fMqH0zEadEPsqfPZoznIzeNGCu37AyMewOJzId+zlgmRz1R7O1kqhbyPZg==
   dependencies:
     "@maxmind/geoip2-node" "^2.3.1"
 
@@ -29,13 +29,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
   integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
 
-"@types/pg@^7.14.11":
-  version "7.14.11"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.11.tgz#daf5555504a1f7af4263df265d91f140fece52e3"
-  integrity sha512-EnZkZ1OMw9DvNfQkn2MTJrwKmhJYDEs5ujWrPfvseWNoI95N8B4HzU/Ltrq5ZfYxDX/Zg8mTzwr6UAyTjjFvXA==
+"@types/pg@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.0.tgz#34233b891a127d6caaad28e177b1baec1a2958d4"
+  integrity sha512-3JXFrsl8COoqVB1+2Pqelx6soaiFVXzkT3fkuSNe7GB40ysfT0FHphZFPiqIXpMyTHSFRdLTyZzrFBrJRPAArA==
   dependencies:
     "@types/node" "*"
-    pg-protocol "^1.2.0"
+    pg-protocol "*"
     pg-types "^2.2.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
@@ -148,7 +148,7 @@ pg-pool@^3.3.0:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.3.0.tgz#12d5c7f65ea18a6e99ca9811bd18129071e562fc"
   integrity sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==
 
-pg-protocol@^1.2.0, pg-protocol@^1.5.0:
+pg-protocol@*, pg-protocol@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==


### PR DESCRIPTION
Few small tweaks:
- Upgrade to latest plugin-scaffold (types)
- Change the "upload every X minutes" to seconds. It's probably Best to flush the buffer as often as possible from our side. Keeping 10MB of events for 60 minutes before flushing seems way too long. Now the max is 10 minutes, with 30sec being the default.